### PR TITLE
Allow extra characters in header values

### DIFF
--- a/src/GWSocket.cpp
+++ b/src/GWSocket.cpp
@@ -313,10 +313,11 @@ bool GWSocket::setCookie(std::string key, std::string value)
 
 
 //Source: https://greenbytes.de/tech/webdav/rfc7230.html#rule.token.separators
-static std::regex headerRegex(R"(^[\w\!#\$%'\*\+\-\.\^_`\|~]*$)");
+static std::regex headerNameRegex(R"(^[\w\!#\$%'\*\+\-\.\^_`\|~]*$)");
+static std::regex headerValueRegex(R"(^[\w\!#\$%'\*\+\-\.\^_`\|~ \(\),;:\/@=]*$)");
 bool GWSocket::setHeader(std::string key, std::string value)
 {
-	if (!std::regex_match(key, headerRegex) || key.empty() || !std::regex_match(value, headerRegex))
+	if (!std::regex_match(key, headerNameRegex) || key.empty() || !std::regex_match(value, headerValueRegex))
 	{
 		return false;
 	}


### PR DESCRIPTION
### Summary

This change allows for a few extra characters which are very common across the current web to be used in the header field values for the websocket handshake/upgrade request.

### Reasoning

* Space: This is used in the [Authorization](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization) header to separate the type and credentials, it is also very common in [User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent)'s too when separating each product field.
* `(` and `)`: This is used in the [User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent) header when specifying extra system or platform details.
* `,` and `;`: Many common headers that specify "things which are allowed or disallowed" or "lists of things", these use comma/semicolon-seperated values. Examples include [Accept](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept), [Accept-Encoding](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding), [Content-Type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) and [Connection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection).
* `:` and `/`: The [Host](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Host), [Origin](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin) and [Referer](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referer) headers can have these characters in their values to separate IP address and port, or after the scheme. Also, base64 uses a `/` as one of its characters and header values can sometimes be encoded to base64 if special characters are being transferred.
* `@`: Used in Email addresses in the [From](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/From) header.
* `=`: Used when a header contains key-value pairs, such as [Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie) and [Range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range).

### Notes

1. Instead of modifying [`headerRegex`](https://github.com/FredyH/GWSockets/blob/33b946eab0d8c8640eb4097d44327d46e1b2de6b/src/GWSocket.cpp#L316), I split the pattern for the header field name and field value into two patterns ([the same as cookie](https://github.com/FredyH/GWSockets/blob/33b946eab0d8c8640eb4097d44327d46e1b2de6b/src/GWSocket.cpp#L298-L299)) for finer control, since all the characters I've added to the header field value pattern should not be used in header field names. 
2. There's a few characters in the header field name pattern which shouldn't be there (such as `~`, `|`, `*`, etc.), but I've decided to leave them for backwards compatibility (in case someone is using them, for whatever reason).