### PR TITLE
Change example servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ require("gwsockets")
 
   *NOTE:* URL's must include the scheme ( Either `ws://` or `wss://` )
 
-  `Example: "wss://example.com:9999/api/socketserver"`
+  `Example: "wss://echo.websocket.events/api/socketserver"`
 
   ```LUA
   GWSockets.createWebSocket( url, verifyCertificate=true )
@@ -108,7 +108,7 @@ require("gwsockets")
 
 ```LUA
 require("gwsockets")
-local socket = GWSockets.createWebSocket("wss://echo.websocket.org/")
+local socket = GWSockets.createWebSocket("wss://echo.websocket.events/")
 
 function socket:onMessage(txt)
     print("Received: ", txt)

--- a/examples/echo.lua
+++ b/examples/echo.lua
@@ -1,5 +1,5 @@
 require("gwsockets")
-local socket = GWSockets.createWebSocket("wss://echo.websocket.org/")
+local socket = GWSockets.createWebSocket("wss://echo.websocket.events/")
 
 function socket:onMessage(txt)
 	print("Received: ", txt)

--- a/src/GLua.cpp
+++ b/src/GLua.cpp
@@ -502,7 +502,7 @@ int main()
 	initialize();
 	try
 	{
-		GWSocket *socket = createWebSocketFromURL("wss://echo.websocket.org", true);
+		GWSocket *socket = createWebSocketFromURL("wss://echo.websocket.events", true);
 		socket->open();
 		std::thread t1(runIOThread);
 		std::thread t2(sendMessages, socket);

--- a/tests/ssltest.lua
+++ b/tests/ssltest.lua
@@ -45,7 +45,7 @@ timer.Simple(10, function()
 	end
 
 	local goodURLs = {
-		"wss://echo.websocket.org"
+		"wss://echo.websocket.events"
 	}
 	local connected = {}
 	for k,v in pairs(goodURLs) do


### PR DESCRIPTION
The `example.com:9999` server in the README no longer works (https://github.com/FredyH/GWSockets/issues/29).

Same goes for the `echo.websocket.org` servers, visiting or websocket connecting to said domain now just shows that the service no longer available.
![image](https://user-images.githubusercontent.com/19510403/163713798-bf2dd935-6910-4c51-b1fa-34ba78bb20ca.png)

All references to these have been changed to `echo.websocket.events`, which is a working alternative for both plain and secure connections, checked with [websocat](https://github.com/vi/websocat).