### PR TITLE
Add support for `permessage-deflate` when sending or receiving messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ require("gwsockets")
   GWSockets.addVerifyPath( "/etc/ssl/certs" )
   ```
 
+* If you would like to enable the `permessage-deflate` extension which allows you to send and receive compressed messages, you can enable it with the following functions:
+
+  ```LUA
+  -- Do note this will only be enabled if the websocket server supports permessage-deflate and enables it during handshake.
+  WEBSOCKET:setMessageCompression(true)
+  ```
+
+* You can also disable context takeover during compression, which will prevent re-using the same compression context over multiple messages.
+  This will decrease the memory usage at the cost of a worse compression ratio.
+
+  ```LUA
+  WEBSOCKET:setDisableContextTakeover(true)
+  ```
+
+ *WARNING:* Enabling compression over encrypted connections (`WSS://`) may make you vulnerable to [CRIME](https://en.wikipedia.org/wiki/CRIME)/[BREACH](https://en.wikipedia.org/wiki/BREACH) attacks.
+            Make sure you know what you are doing, or avoid sending sensitive information over websocket messages.
+
 * Next add any cookies or headers you would like to send with the initial request (Optional)
 
   ```LUA

--- a/src/GLua.cpp
+++ b/src/GLua.cpp
@@ -219,6 +219,34 @@ LUA_FUNCTION(socketSetHeader)
 	return 0;
 }
 
+LUA_FUNCTION(socketSetMessageCompression)
+{
+	GWSocket* socket = getCppObject<GWSocket>(LUA);
+	if (socket->state != STATE_DISCONNECTED)
+	{
+		LUA->ThrowError("Cannot set message compression for an already connected websocket");
+	}
+
+	LUA->CheckType(2, Type::BOOL);
+	socket->setPerMessageDeflate(LUA->GetBool(2));
+
+	return 0;
+}
+
+LUA_FUNCTION(socketSetDisableContextTakeover)
+{
+	GWSocket* socket = getCppObject<GWSocket>(LUA);
+	if (socket->state != STATE_DISCONNECTED)
+	{
+		LUA->ThrowError("Cannot set compression takeover for an already connected websocket");
+	}
+
+	LUA->CheckType(2, Type::BOOL);
+	socket->setDisableContextTakeover(LUA->GetBool(2));
+
+	return 0;
+}
+
 LUA_FUNCTION(socketIsConnected)
 {
 	GWSocket* socket = getCppObject<GWSocket>(LUA);
@@ -422,6 +450,10 @@ GMOD_MODULE_OPEN()
 	LUA->SetField(-2, "setCookie");
 	LUA->PushCFunction(socketSetHeader);
 	LUA->SetField(-2, "setHeader");
+	LUA->PushCFunction(socketSetMessageCompression);
+	LUA->SetField(-2, "setMessageCompression");
+	LUA->PushCFunction(socketSetDisableContextTakeover);
+	LUA->SetField(-2, "setDisableContextTakeover");
 	LUA->PushCFunction(socketIsConnected);
 	LUA->SetField(-2, "isConnected");
 	LUA->PushCFunction(socketClearQueue);

--- a/src/GWSocket.cpp
+++ b/src/GWSocket.cpp
@@ -328,3 +328,13 @@ bool GWSocket::setHeader(std::string key, std::string value)
 	this->headers[key] = value;
 	return true;
 }
+
+void GWSocket::setPerMessageDeflate(bool value)
+{
+	perMessageDeflate = value;
+}
+
+void GWSocket::setDisableContextTakeover(bool value)
+{
+	disableContextTakeover = value;
+}

--- a/src/GWSocket.h
+++ b/src/GWSocket.h
@@ -70,6 +70,9 @@ public:
 	void write(std::string message);
 	bool setCookie(std::string key, std::string value);
 	bool setHeader(std::string key, std::string value);
+	void setPerMessageDeflate(bool value);
+	void setDisableContextTakeover(bool value);
+
 	BlockingQueue<GWSocketMessageIn> messageQueue;
 	bool isConnected() { return state == STATE_CONNECTED; };
 	bool canBeDeleted() { return state == STATE_DISCONNECTED; };
@@ -78,6 +81,8 @@ public:
 	std::string host;
 	unsigned int port;
 	std::atomic<SocketState> state{ STATE_DISCONNECTED };
+	bool perMessageDeflate;
+	bool disableContextTakeover;
 
 	static std::unique_ptr<boost::asio::io_context> ioc; //Needs to be initialized on module load
 protected:

--- a/src/SSLWebSocket.h
+++ b/src/SSLWebSocket.h
@@ -28,7 +28,7 @@ protected:
 	void closeSocket();
 	void sslHandshakeComplete(const boost::system::error_code& ec, std::string host, std::string path, std::function<void(websocket::request_type&)> decorator);
 	bool verifyCertificate(bool preverified, boost::asio::ssl::verify_context& ctx);
-	std::atomic<websocket::stream<ssl::stream<tcp::socket>>*> ws{ nullptr };
+	std::atomic<websocket::stream<ssl::stream<tcp::socket>, true>*> ws{ nullptr };
 	//This is not an atomic function, it only ensures visibility.
 	//Callers have to make sure that atomicity is not required/ensured otherwise
 	void resetWS()
@@ -38,8 +38,18 @@ protected:
 		{
 			delete ws;
 		}
-		ws = new websocket::stream<ssl::stream<tcp::socket>>(*ioc, *sslContext);
+
+		auto newWS = new websocket::stream<ssl::stream<tcp::socket>, true>(*ioc, *sslContext);
+
+		// Set permessage-deflate options for message compression if requested.
+		websocket::permessage_deflate opts;
+		opts.client_enable = perMessageDeflate;
+		opts.client_no_context_takeover = disableContextTakeover;
+		newWS->set_option(opts);
+
+		ws = newWS;
 	}
+
 	websocket::stream<ssl::stream<tcp::socket>>* getWS()
 	{
 		return this->ws.load();

--- a/src/WebSocket.h
+++ b/src/WebSocket.h
@@ -32,8 +32,18 @@ protected:
 		{
 			delete ws;
 		}
-		ws = new websocket::stream<tcp::socket>(*ioc);
+
+		auto newWS = new websocket::stream<tcp::socket, true>(*ioc);
+
+		// Set permessage-deflate options for message compression if requested.
+		websocket::permessage_deflate opts;
+		opts.client_enable = perMessageDeflate;
+		opts.client_no_context_takeover = disableContextTakeover;
+		newWS->set_option(opts);
+
+		ws = newWS;
 	}
+
 	websocket::stream<tcp::socket>* getWS()
 	{
 		return this->ws.load();


### PR DESCRIPTION
This PR aims to add support for message compression via the `permessage-deflate` extension. Message compression is disabled by default, and can be configured via the following functions:

```lua
-- Enable message compression.
WEBSOCKET:setMessageCompression(true)
-- Disable context takeover, meaning the compression context will not be used across multiple messages.
-- Less memory usage, but worse compression ratio.
WEBSOCKET:setDisableContextTakeover(true)
```

Do note that enabling message compression on the websocket client will not necessarily mean it will be enabled, as it is negotiated with the websocket server during handshake (and the server must allow it).

I modified the README as well to document the new functions and add a warning about CRIME/BREACH attacks which occur when compressing responses in a secure connection (HTTPS/WSS). The library in its current state does not enable us to disable compression on a per-message basis, so it's up to the end user to be smart with what they do (which is why it's disabled by default).
