### PR TITLE
Add parameter to disable clearing queue on open().

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ require("gwsockets")
   WEBSOCKET:open( shouldClearQueue = true )
   ```
   
+  *NOTE:* By default, opening a connection will clear the queued messages. This is due to the fact there
+  is no way of knowing what's in the queue, and what has been received by the remote. If you would like to
+  disable this, you may use `open(false)`.
+  
 * Once the socket has been opened you can send messages using the `write` function
 
   ```LUA
@@ -95,8 +99,7 @@ require("gwsockets")
 
   *NOTE:* You can write messages to the socket before the connection has been established and the socket
   will wait before sending them until the connection has been established. However, it is best practice
-  to only start sending in the onConnected() callback. To enable this, call `open(false)` to disable
-  message clearing on connection.
+  to only start sending in the onConnected() callback.
 
 * You can close the websocket connection at any time using `close` OR `closeNow`
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ require("gwsockets")
 * Lastly open the connection
 
   ```LUA
-  WEBSOCKET:open()
+  WEBSOCKET:open(shouldClearQueue = true)
   ```
   
 * Once the socket has been opened you can send messages using the `write` function
@@ -95,7 +95,8 @@ require("gwsockets")
 
   *NOTE:* You can write messages to the socket before the connection has been established and the socket
   will wait before sending them until the connection has been established. However, it is best practice
-  to only start sending in the onConnected() callback.
+  to only start sending in the onConnected() callback. To enable this, call `open(false)` to disable
+  message clearing on connection.
 
 * You can close the websocket connection at any time using `close` OR `closeNow`
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ require("gwsockets")
 * Lastly open the connection
 
   ```LUA
-  WEBSOCKET:open(shouldClearQueue = true)
+  WEBSOCKET:open( shouldClearQueue = true )
   ```
   
 * Once the socket has been opened you can send messages using the `write` function

--- a/src/GLua.cpp
+++ b/src/GLua.cpp
@@ -169,6 +169,9 @@ LUA_FUNCTION(socketOpen)
 	{
 		LUA->ThrowError("Cannot open socket that is already connected");
 	}
+
+	const bool shouldClearQueue = LUA->IsType(2, Type::BOOL) ? LUA->GetBool(2) : true;
+	
 	//As soon as the socket starts connecting we want to keep a reference to the table so that it does not
 	//get garbage collected, so that the callbacks can be called.
 	if (socketTableReferences.find(socket) == socketTableReferences.end())
@@ -176,7 +179,7 @@ LUA_FUNCTION(socketOpen)
 		LUA->Push(1);
 		socketTableReferences[socket] = LUA->ReferenceCreate();
 	}
-	socket->open();
+	socket->open(shouldClearQueue);
 	return 0;
 }
 

--- a/src/GWSocket.cpp
+++ b/src/GWSocket.cpp
@@ -218,7 +218,7 @@ void GWSocket::open()
 	{
 		return;
 	}
-	this->clearQueue();
+	
 	// Look up the domain name
 	this->resolver.async_resolve(host, std::to_string(port), boost::bind(&GWSocket::hostResolvedStep, this, boost::asio::placeholders::error, boost::asio::placeholders::iterator));
 }

--- a/src/GWSocket.cpp
+++ b/src/GWSocket.cpp
@@ -211,12 +211,18 @@ void GWSocket::hostResolvedStep(const boost::system::error_code &ec, tcp::resolv
 	}
 }
 
-void GWSocket::open()
+void GWSocket::open(bool shouldClearQueue)
 {
 	auto expected = STATE_DISCONNECTED;
 	if (!this->state.compare_exchange_strong(expected, STATE_CONNECTING))
 	{
 		return;
+	}
+
+	// Clear the queue if it was requested.
+	if (shouldClearQueue)
+	{
+		this->clearQueue();
 	}
 	
 	// Look up the domain name

--- a/src/GWSocket.h
+++ b/src/GWSocket.h
@@ -63,7 +63,7 @@ public:
 	GWSocket(std::string host, unsigned short port, std::string path) : host(host), port(port), path(path) { };
 	virtual ~GWSocket() { };
 
-	void open();
+	void open(bool shouldClearQueue = true);
 	void onDisconnected(const boost::system::error_code & ec);
 	bool close();
 	bool closeNow();


### PR DESCRIPTION
Fixes #45 

Makes the lib behave in line with what the README says about queueing messages until the websocket is open.
Seems like this behaviour was changed in https://github.com/FredyH/GWSockets/commit/f39894cca62984934ddf87d0a29647858dac6ac1 so if there's any actual reason, let me know and I can try my hand at a workaround.

EDIT: Modified this so that `open()` now takes in an optional bool. By default, it will clear the queue, since that's been the behaviour for a long time now and I don't want to break servers using it.

However, if you want to disable it, you can just do `open(false)`.
