### PR TITLE
Change think hook to timer for callback execution

### DIFF
--- a/src/GLua.cpp
+++ b/src/GLua.cpp
@@ -430,14 +430,14 @@ GMOD_MODULE_OPEN()
 
 	//Adds a timer that calls the callbacks, using a timer as it runs during hibernation
 	LUA->PushSpecial(GarrysMod::Lua::SPECIAL_GLOB);
-    LUA->GetField(-1, "timer");
-    LUA->GetField(-1, "Create");
-    LUA->PushString("__GWSocketTimer");
-    LUA->PushNumber(0);
-    LUA->PushNumber(0);
-    LUA->PushCFunction(webSocketThink);
-    LUA->Call(4, 0);
-    LUA->Pop(2);
+	LUA->GetField(-1, "timer");
+	LUA->GetField(-1, "Create");
+	LUA->PushString("__GWSocketTimer");
+	LUA->PushNumber(0);
+	LUA->PushNumber(0);
+	LUA->PushCFunction(webSocketThink);
+	LUA->Call(4, 0);
+	LUA->Pop(2);
 
 	//Prototype table
 	LUA->CreateTable();


### PR DESCRIPTION
Currently gwsockets uses a think hook which doesn't run during server hibernation, a 0 time timer does.

I haven't been able to test this exact PR but i do the exact same for other dlls and it works fine in there.